### PR TITLE
fix(tui): show API key for custom providers

### DIFF
--- a/src/cli/tui/tests.rs
+++ b/src/cli/tui/tests.rs
@@ -53,6 +53,55 @@ fn custom_provider_form_builds_complete_cli_arguments() {
 }
 
 #[test]
+fn custom_provider_api_key_is_visible_and_masked_in_setup_and_add() {
+    for setup in [true, false] {
+        for (width, height) in [(80, 24), (100, 30)] {
+            let snapshot = Snapshot {
+                status: serde_json::json!({"configured": false}),
+                providers: Vec::new(),
+                codex_install_mode: None,
+                benchmark: None,
+                usage: Vec::new(),
+                models: Vec::new(),
+                fusion_profile: None,
+                refreshed_at: Instant::now(),
+            };
+            let mut app = App::new(snapshot, StartPage::Setup);
+            let mut form = AddProviderForm {
+                preset_index: PROVIDER_PRESETS
+                    .iter()
+                    .position(|preset| *preset == "custom")
+                    .unwrap(),
+                focus: 4,
+                ..AddProviderForm::default()
+            };
+            form.move_focus(1);
+            form.focused_text().unwrap().push_str("test-api-key");
+            assert_eq!(form.api_key, "test-api-key");
+            if setup {
+                app.setup.focus = form.focus;
+                app.setup.provider = form;
+            } else {
+                app.dialog = Some(Dialog::AddProvider(form));
+            }
+            let backend = ratatui::backend::TestBackend::new(width, height);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|frame| render(frame, &app)).unwrap();
+            let rendered = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(ratatui::buffer::Cell::symbol)
+                .collect::<String>();
+            assert!(rendered.contains("\u{203a} API key"));
+            assert!(rendered.contains("************"));
+            assert!(!rendered.contains("test-api-key"));
+        }
+    }
+}
+
+#[test]
 fn baidu_provider_form_submits_gui_parity_settings() {
     let form = AddProviderForm {
         api_key: "secret".to_owned(),

--- a/src/cli/tui/view.rs
+++ b/src/cli/tui/view.rs
@@ -227,7 +227,8 @@ pub(super) fn render_setup(frame: &mut ratatui::Frame<'_>, area: Rect, app: &App
                 true,
             ),
         ]);
-    } else {
+    }
+    if !is_aws_bedrock(provider.preset()) {
         lines.push(form_line(
             "API key",
             &provider.api_key,
@@ -1399,7 +1400,8 @@ pub(super) fn render_dialog(
                         true,
                     ),
                 ]);
-            } else {
+            }
+            if !is_aws_bedrock(form.preset()) {
                 lines.push(form_line("API key", &form.api_key, form.focus == 5, true));
             }
             if form.preset() == "baidu-oneapi" {


### PR DESCRIPTION
## 变更摘要

TUI 首次配置和新增 Provider 页面选择 `custom` 后不显示 API Key 输入框，但提交时仍要求 API Key，导致用户无法正常完成配置。

将 API Key 的显示判断从 Custom/AWS 的互斥分支中独立出来，使所有非 AWS Bedrock Provider 都显示该字段。新增回归测试，覆盖首次配置和新增页面、80×24 与 100×30 两种终端尺寸，以及字段焦点、输入和密钥掩码。

## 关联 issue

无。

## 测试

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked --all-targets`：627 项通过，4 项跳过
- [x] `cargo build --locked --release`
- [x] 回归测试在修复前失败、修复后通过
- [x] 手工验证：进入 TUI 的新增 Custom Provider 页面，切换到 API Key 字段并输入测试文本，确认显示星号；未保存测试配置
- 不涉及 macOS App 源码或 prompt cache，无需对应专项测试

## 检查清单

- [x] 没有混入与本次变更无关的修改
- [x] 没有隐藏 fallback、mock 或静默降级
- [x] 没有提交 API Key、Token、Cookie 等敏感信息
- [x] 新增或修改的行为有对应验证
